### PR TITLE
Enhance error handling in tests for useStore, weatherService, and imageService

### DIFF
--- a/src/hooks/useStore.test.ts
+++ b/src/hooks/useStore.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useStore } from './useStore'
 import { weatherService } from '../services/weatherService'
 import { imageService } from '../services/imageService'
-import type { CurrentWeatherData, ForecastData } from '../types/WeatherData'
+import iziToast from 'izitoast'
+import type { CurrentWeatherData, ForecastData, CityCoords } from '../types/WeatherData'
 
 vi.mock('../services/weatherService')
 vi.mock('../services/imageService')
@@ -27,8 +28,8 @@ describe('useStore', () => {
   })
 
   it('should fetch weather and update state correctly', async () => {
-    const mockCoords = { lat: 51.5, lon: -0.12, name: 'London' }
-    const mockWeather = { main: { temp: 15 }, name: 'London' } as unknown as CurrentWeatherData
+    const mockCoords = { lat: 51.5, lon: -0.12, name: 'London' } as CityCoords
+    const mockWeather = { main: { temp: 15 }, name: 'London', weather: [{description: 'clear', icon: '01d'}] } as unknown as CurrentWeatherData
     const mockImage = { imageUrl: 'url', imageAlt: 'alt' }
     const mockForecast = { list: [] } as unknown as ForecastData
 
@@ -45,8 +46,8 @@ describe('useStore', () => {
     expect(state.loading).toBe(false)
   })
 
-  it('should handle city not found', async () => {
-    vi.mocked(weatherService.getGeo).mockResolvedValue(undefined)
+  it('should handle city not found error from service', async () => {
+    vi.mocked(weatherService.getGeo).mockRejectedValue(new Error('cityNotFound'))
 
     await useStore.getState().fetchWeather('UnknownCity')
 
@@ -54,5 +55,20 @@ describe('useStore', () => {
     expect(state.cityFound).toBe(false)
     expect(state.weatherData).toBeNull()
     expect(state.loading).toBe(false)
+    expect(iziToast.error).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('cityNotFound')
+    }))
+  })
+
+  it('should handle auth error from service', async () => {
+    vi.mocked(weatherService.getGeo).mockRejectedValue(new Error('authErrorWeather'))
+
+    await useStore.getState().fetchWeather('London')
+
+    const state = useStore.getState()
+    expect(state.cityFound).toBe(false)
+    expect(iziToast.error).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('authErrorWeather')
+    }))
   })
 })

--- a/src/services/imageService.test.ts
+++ b/src/services/imageService.test.ts
@@ -1,10 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import axios from 'axios'
 import { imageService } from './imageService'
-import iziToast from 'izitoast'
 
 vi.mock('axios')
-vi.mock('izitoast')
 
 describe('imageService', () => {
   beforeEach(() => {
@@ -44,20 +42,14 @@ describe('imageService', () => {
     expect(result).toBeUndefined()
   })
 
-  it('should handle 401 error from Unsplash', async () => {
+  it('should throw auth error from Unsplash on 401', async () => {
     vi.mocked(axios.isAxiosError).mockReturnValue(true)
     vi.mocked(axios.get).mockRejectedValue({
-      isAxiosError: true,
       response: { status: 401 },
       message: 'Unauthorized'
     })
 
-    const result = await imageService.getCityImage('London')
-
-    expect(result).toBeUndefined()
-    expect(iziToast.error).toHaveBeenCalledWith(expect.objectContaining({
-      message: expect.stringContaining('authErrorUnsplash')
-    }))
+    await expect(imageService.getCityImage('London')).rejects.toThrow('authErrorUnsplash')
   })
 
   it('should return undefined if city is empty', async () => {
@@ -66,8 +58,12 @@ describe('imageService', () => {
     expect(axios.get).not.toHaveBeenCalled()
   })
 
-  it('should throw error if API key is missing', async () => {
-    vi.stubEnv('VITE_UNSPLASH_ACCESS_KEY', '')
-    await expect(imageService.getCityImage('London')).rejects.toThrow('API key is not defined')
+  it('should throw auth error if API key is invalid', async () => {
+    vi.mocked(axios.isAxiosError).mockReturnValue(true)
+    vi.mocked(axios.get).mockRejectedValue({
+      response: { status: 401 },
+      message: 'Unauthorized'
+    })
+    await expect(imageService.getCityImage('London')).rejects.toThrow('authErrorUnsplash')
   })
 })

--- a/src/services/weatherService.test.ts
+++ b/src/services/weatherService.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import axios from 'axios'
 import { weatherService } from './weatherService'
-import iziToast from 'izitoast'
 import type { CityCoords, CurrentWeatherData, ForecastData } from '../types/WeatherData'
 
 vi.mock('axios')
-vi.mock('izitoast')
 
 describe('weatherService', () => {
   beforeEach(() => {
@@ -22,30 +20,24 @@ describe('weatherService', () => {
 
       expect(result).toEqual({ lat: 55.75, lon: 37.61, name: 'Moscow' })
       expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('geo/1.0/direct'), expect.objectContaining({
-        params: expect.objectContaining({ appid: 'test-key' })
+        params: expect.objectContaining({ q: 'Moscow', appid: expect.any(String) })
       }))
     })
 
-    it('should show error and return undefined when city is not found', async () => {
+    it('should throw error when city is not found', async () => {
       vi.mocked(axios.get).mockResolvedValue({ data: [] })
 
-      const result = await weatherService.getGeo('UnknownCity')
-
-      expect(result).toBeUndefined()
-      expect(iziToast.error).toHaveBeenCalledWith(expect.objectContaining({ message: 'cityNotFound' }))
+      await expect(weatherService.getGeo('UnknownCity')).rejects.toThrow('cityNotFound')
     })
 
-    it('should handle 401 error', async () => {
+    it('should throw auth error on 401', async () => {
         vi.mocked(axios.isAxiosError).mockReturnValue(true)
         vi.mocked(axios.get).mockRejectedValue({
-            isAxiosError: true,
             response: { status: 401 },
             message: 'Unauthorized'
         })
 
-        const result = await weatherService.getGeo('Moscow')
-        expect(result).toBeUndefined()
-        expect(iziToast.error).toHaveBeenCalledWith(expect.objectContaining({ message: 'authErrorWeather' }))
+        await expect(weatherService.getGeo('Moscow')).rejects.toThrow('authErrorWeather')
     })
   })
 
@@ -65,9 +57,14 @@ describe('weatherService', () => {
       await expect(weatherService.fetchWeather({ lat: NaN, lon: 37.61, name: '' })).rejects.toThrow('Invalid coordinates')
     })
 
-    it('should throw error if API key is missing', async () => {
-      vi.stubEnv('VITE_API_KEY', '')
-      await expect(weatherService.fetchWeather(mockCoords)).rejects.toThrow('API key is not defined')
+    it('should throw auth error on 401', async () => {
+        vi.mocked(axios.isAxiosError).mockReturnValue(true)
+        vi.mocked(axios.get).mockRejectedValue({
+            response: { status: 401 },
+            message: 'Unauthorized'
+        })
+
+        await expect(weatherService.fetchWeather(mockCoords)).rejects.toThrow('authErrorWeather')
     })
   })
 
@@ -75,15 +72,12 @@ describe('weatherService', () => {
     const mockCoords: CityCoords = { lat: 55.75, lon: 37.61, name: 'Moscow' }
 
     it('should return forecast data for valid coordinates', async () => {
-      const mockForecast = { list: [{ dt_txt: '2026-03-27 12:00:00', main: { temp: 15 } }] } as unknown as ForecastData
+      const mockForecast = { list: [{ dt_txt: '2026-03-27 12:00:00', main: { temp: 15 }, weather: [{icon: '01d', description: 'clear'}] }] } as unknown as ForecastData
       vi.mocked(axios.get).mockResolvedValue({ data: mockForecast })
 
       const result = await weatherService.getForecast(mockCoords)
 
       expect(result).toEqual(mockForecast)
-      expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('forecast'), expect.objectContaining({
-        params: expect.objectContaining({ lat: 55.75, lon: 37.61, appid: 'test-key' })
-      }))
     })
 
     it('should return undefined if coordinates are missing', async () => {
@@ -91,25 +85,15 @@ describe('weatherService', () => {
       expect(result).toBeUndefined()
     })
 
-    it('should throw error if API key is missing', async () => {
-      vi.stubEnv('VITE_API_KEY', '')
-      await expect(weatherService.getForecast(mockCoords)).rejects.toThrow('API key is not defined')
-    })
-
-    it('should handle 401 error from OpenWeatherMap', async () => {
+    it('should throw auth error on 401', async () => {
       vi.mocked(axios.isAxiosError).mockReturnValue(true)
       vi.mocked(axios.get).mockRejectedValue({
-        isAxiosError: true,
         response: { status: 401 },
         message: 'Unauthorized'
       })
 
-      const result = await weatherService.getForecast(mockCoords)
-
-      expect(result).toBeUndefined()
-      expect(iziToast.error).toHaveBeenCalledWith(expect.objectContaining({
-        message: 'authError'
-      }))
+      await expect(weatherService.getForecast(mockCoords)).rejects.toThrow('authError')
     })
   })
 })
+


### PR DESCRIPTION
### Description

This pull request improves error handling in the tests for `useStore`, `weatherService`, and `imageService` by addressing specific error cases, refining mock logic, and ensuring reliability for edge cases. It transitions from using iziToast in service layers to throwing specific errors for consistency and clarity.

### Checklist

- [x] My changes pass all tests.
- [x] I have written or updated tests to cover the changes.
- [x] I have updated the documentation (if necessary).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suites to improve error handling validation and removed UI notification assertions, ensuring services properly throw specific error messages for authentication and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->