### PR TITLE
fix: conditionally display suggestions dropdown in search field

### DIFF
--- a/src/components/VillageSearchField/VillageSearchField.tsx
+++ b/src/components/VillageSearchField/VillageSearchField.tsx
@@ -38,6 +38,9 @@ export default function VillageSearchField() {
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setCity(e.target.value);
+    if (suggestions.length !== 0) {
+      setIsVisible(true);
+    }
   };
 
   const handleSuggestionClick = (suggestion: CityCoords) => {
@@ -91,7 +94,11 @@ export default function VillageSearchField() {
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
               placeholder={t('enterCityName')}
-              onFocus={() => setIsVisible(true)}
+              onFocus={() => {
+                if (suggestions.length !== 0) {
+                  setIsVisible(true);
+                }
+              }}
               onBlur={() => setTimeout(() => setIsVisible(false), 200)}
             />
           </label>


### PR DESCRIPTION
- Updated input `onFocus` and `onChange` logic to check for non-empty suggestions before toggling visibility.
- Prevented unnecessary dropdown visibility when no suggestions are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed suggestions dropdown visibility in the village search field. The dropdown now only displays when suggestions are available, preventing an empty dropdown from appearing to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->